### PR TITLE
fix check_run:rerequested handling in brigade.ts

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -128,7 +128,7 @@ events.on("brigade.sh/github", "check_suite:rerequested", runSuite)
 
 // This event indicates a specific job is to be re-run.
 events.on("brigade.sh/github", "check_run:rerequested", async event => {
-  const jobName = JSON.parse(event.payload).check_run.name
+  const jobName = JSON.parse(event.payload).check_run.name.slice(event.project.id.length + 1)
   const job = jobs[jobName]
   if (job) {
     await job(event).run()


### PR DESCRIPTION
This brigade.ts was copied/modified from the github gateway's, which was written before the github gateway started prefixing check names with project names.

This PR accounts for that change when an event requests re-execution of a specific check.