### PR TITLE
use ClusterIP as the default service type

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ Edit `~/brigade-slack-gateway-values.yaml`, making the following changes:
 * `receiver.host`: Set this to the host name where you'd like the gateway to be
   accessible.
 
+* `receiver.service.type`: If you plan to enable ingress (advanced), you can
+  leave this as its default -- `ClusterIP`. If you do not plan to enable
+  ingress, you probably will want to change this value to `LoadBalancer`.
+
 Save your changes to `~/brigade-slack-gateway-values.yaml` and use the following
 command to install the gateway using the above customizations:
 
@@ -175,13 +179,15 @@ $ helm install brigade-slack-gateway \
     --version v0.1.0 \
     --create-namespace \
     --namespace brigade-slack-gateway \
-    --values ~/brigade-slack-gateway-values.yaml
+    --values ~/brigade-slack-gateway-values.yaml \
+    --wait \
+    --timeout 300s
 ```
 
 ### 4. (RECOMMENDED) Create a DNS Entry
 
-If you installed the gateway without enabling support for an ingress controller,
-this command should help you find the gateway's public IP address:
+If you overrode defaults and set `receiver.service.type` to `LoadBalancer`, use
+this command to find the gateway's public IP address:
 
 ```console
 $ kubectl get svc brigade-slack-gateway-receiver \

--- a/charts/brigade-slack-gateway/values.yaml
+++ b/charts/brigade-slack-gateway/values.yaml
@@ -47,9 +47,8 @@ receiver:
     # key: base 64 encoded key goes here
 
   ingress:
-    ## Whether to enable ingress. By default, this is disabled and the gateway's
-    ## service is of type LoadBalancer instead. Enabling ingress is advanced
-    ## usage.
+    ## Whether to enable ingress. By default, this is disabled. Enabling ingress
+    ## is advanced usage.
     enabled: false
     ## For Kubernetes 1.18+, this field is supported. IF your ingress controller
     ## also supports it, this is an alternative to using the
@@ -106,10 +105,15 @@ receiver:
   tolerations: []
 
   service:
-    ## If you're going to use an ingress controller, you can change the service
-    ## type to CLusterIP.
-    type: LoadBalancer
-    # nodePort: 31700
+    ## If you're not going to use an ingress controller, you may want to change
+    ## this value to LoadBalancer for production deployments. If running
+    ## locally, you may want to change it to NodePort OR leave it as ClusterIP
+    ## and use `kubectl port-forward` to map a port on the local network
+    ## interface to the service.
+    type: ClusterIP
+    ## Host port the service will be mapped to when service type is either
+    ## NodePort or LoadBalancer. If not specified, Kubernetes chooses.
+    # nodePort:
 
 ## All settings for the monitor
 monitor:


### PR DESCRIPTION
This leads to a smoother install experience because we can use `--wait`.